### PR TITLE
deps: update for direct-minimal-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,22 @@ jobs:
           components: clippy
       - run: cargo clippy -- -D warnings
 
+  direct-minimal-versions:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: clippy
+
+      - run: cargo update -Z direct-minimal-versions
+      - run: cargo clippy -- -D warnings
+
   rustfmt:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-integer = "0.1.44"
-num-traits = "0.2.14"
+num-integer = "0.1.46"
+num-traits = "0.2.18"
 num-modular = "0.6.1"
 bitvec = "1.0.0"
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-integer = "0.1.44"
-num-traits = "0.2.14"
+num-integer = "0.1.46"
+num-traits = "0.2.18"
 num-modular = "0.6.1"
 bitvec = "1.0.0"
 rand = "0.8.6"

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -15,10 +15,10 @@ num-primes = { version = "0.3.0", optional = true }
 [dev-dependencies]
 criterion = { version = "4.4.1", package = "codspeed-criterion-compat" }
 glass_pumpkin = "1.2.0"
-num-bigint = { version = "0.4", features = ["rand"] }
+num-bigint = { version = "0.4.6", features = ["rand"] }
 num-prime = { path = "..", features = ["big-int"] }
 primal-check = "0.3.1"
-rand = "0.8"
+rand = "0.8.4"
 rand_chacha = "0.10"
 rand_core = "0.10"
 

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -15,7 +15,7 @@ num-primes = { version = "0.3.0", optional = true }
 [dev-dependencies]
 criterion = { version = "5.0.0", package = "codspeed-criterion-compat" }
 glass_pumpkin = "1.2.0"
-num-bigint = { version = "0.4", features = ["rand"] }
+num-bigint = { version = "0.4.6", features = ["rand"] }
 num-prime = { path = "..", features = ["big-int"] }
 primal-check = "0.3.1"
 rand = "0.8.6"


### PR DESCRIPTION
Make sure we can build when the lockfile is generated with `direct-minimal-versions`.